### PR TITLE
Tooling is now portable and the linter passes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+package-lock.json

--- a/assets/grid.js
+++ b/assets/grid.js
@@ -7,11 +7,11 @@ $.getJSON('assets/data.json', function (data) {
     var img = $('<img />', {
       'class': 'hex',
       'src': val.raster,
-      'alt': val.description,
+      'alt': val.description
     })
 
     $('<a />', {
-      'href': "http://hexb.in/" + val.filename,
+      'href': 'http://hexb.in/' + val.filename,
       'target': '_blank'
     }).append(img).appendTo('#grid')
   })

--- a/build.js
+++ b/build.js
@@ -10,6 +10,7 @@ glob('meta/*.json', function (err, files) {
     file.filename = f
     data.push(file)
   })
-  
+
   fs.writeFileSync(__dirname + '/assets/data.json', JSON.stringify(data, null, '  '))
 })
+

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "hexagon directory",
   "main": "grid.js",
   "scripts": {
-    "build": "node build.js && browserify assets/grid.js -o assets/bundle.js",
-    "test": "standard",
-    "start": "wzrd assets/grid.js:assets/bundle.js"
+    "build": "node build.js && ./node_modules/.bin/browserify assets/grid.js -o assets/bundle.js",
+    "test": "./node_modules/.bin/standard",
+    "start": "./node_module/.bin/wzrd assets/grid.js:assets/bundle.js"
   },
   "author": "max ogden",
   "license": "BSD",


### PR DESCRIPTION
- Added `package-lock.json` to `.gitignore` because the author didn't commit a lock, and I wasn't about to in their place.
- Prepended `./node_modules/.bin/` to binaries from devdependencies. NPM scripts will be able to run even if the user hasn't installed a global version of the binary.
- Fixed `standard` errors until tests passed.