### PR TITLE
Metadata verification script: warns when metadata missing required fields or when images don't exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+package-lock.json

--- a/assets/grid.js
+++ b/assets/grid.js
@@ -7,11 +7,11 @@ $.getJSON('assets/data.json', function (data) {
     var img = $('<img />', {
       'class': 'hex',
       'src': val.raster,
-      'alt': val.description,
+      'alt': val.description
     })
 
     $('<a />', {
-      'href': "http://hexb.in/" + val.filename,
+      'href': 'http://hexb.in/' + val.filename,
       'target': '_blank'
     }).append(img).appendTo('#grid')
   })

--- a/build.js
+++ b/build.js
@@ -10,6 +10,7 @@ glob('meta/*.json', function (err, files) {
     file.filename = f
     data.push(file)
   })
-  
+
   fs.writeFileSync(__dirname + '/assets/data.json', JSON.stringify(data, null, '  '))
 })
+

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "hexagon directory",
   "main": "grid.js",
   "scripts": {
-    "build": "node build.js && browserify assets/grid.js -o assets/bundle.js",
-    "test": "standard",
-    "start": "wzrd assets/grid.js:assets/bundle.js"
+    "build": "node build.js && ./node_modules/.bin/browserify assets/grid.js -o assets/bundle.js",
+    "test": "./node_modules/.bin/standard",
+    "start": "./node_module/.bin/wzrd assets/grid.js:assets/bundle.js"
   },
   "author": "max ogden",
   "license": "BSD",

--- a/verify.js
+++ b/verify.js
@@ -1,0 +1,31 @@
+var fs = require('fs');
+var glob = require('glob');
+var assert = require('assert');
+
+var REQUIRED_FIELDS = ['name', 'author', 'license', 'vector', 'raster'];
+var OPTIONAL_FIELDS = ['description', 'order_online_url']
+
+glob('meta/*.json', function (err, files) {
+  if (err) throw err
+  files.forEach(function (f) {
+    var file = JSON.parse(fs.readFileSync(f));
+    var fields = Object.keys(file);
+    REQUIRED_FIELDS.forEach(function (requiredField) {
+      if(fields.indexOf(requiredField) === -1) {
+        console.warn(`Warning: Missing required field ${requiredField} in ${f}`)
+      }
+      // assert.ok(fields.indexOf(requiredField) !== -1, `Missing required field ${requiredField} in ${f}`)
+    })
+    fields.forEach(function (field) {
+      if (REQUIRED_FIELDS.indexOf(field) === -1) {
+        if (OPTIONAL_FIELDS.indexOf(field) === -1) {
+          console.warn(`Warning: ${field} is not a required or optional field: ${f}`)
+        }
+      }
+    })
+    if (file['name'].match(/[^a-z\d-]/) !== null) {
+      console.warn(`Warning: Invalid 'name' field value '${file['name']}' in ${f}, only alphanumeric characters and hyphens are allowed`);
+    }
+    // assert.ok(fields['name'].match(/[^\w\d-]/) !== null, `Invalid 'name' field value '${fields['name']}' in ${f}, only alphanumeric characters and hyphens are allowed`)
+  })
+})

--- a/verify.js
+++ b/verify.js
@@ -1,31 +1,73 @@
-var fs = require('fs');
-var glob = require('glob');
-var assert = require('assert');
+var fs = require('fs')
+var glob = require('glob')
 
-var REQUIRED_FIELDS = ['name', 'author', 'license', 'vector', 'raster'];
+var REQUIRED_FIELDS = ['name', 'author', 'license', 'vector', 'raster']
 var OPTIONAL_FIELDS = ['description', 'order_online_url']
 
 glob('meta/*.json', function (err, files) {
   if (err) throw err
   files.forEach(function (f) {
-    var file = JSON.parse(fs.readFileSync(f));
-    var fields = Object.keys(file);
+    var file = JSON.parse(fs.readFileSync(f))
+    var fields = Object.keys(file)
+
+    /**
+     * Rule: all required fields must be defined
+     */
     REQUIRED_FIELDS.forEach(function (requiredField) {
-      if(fields.indexOf(requiredField) === -1) {
-        console.warn(`Warning: Missing required field ${requiredField} in ${f}`)
+      if (fields.indexOf(requiredField) === -1) {
+        console.warn(`Warning: ${f}: Missing required field ${requiredField}`)
       }
-      // assert.ok(fields.indexOf(requiredField) !== -1, `Missing required field ${requiredField} in ${f}`)
+      // FIXME: Some entries lack required fields (particularly `vector`)
     })
+
+    /**
+     * Rule: only required and optional fields may appear
+     */
     fields.forEach(function (field) {
       if (REQUIRED_FIELDS.indexOf(field) === -1) {
         if (OPTIONAL_FIELDS.indexOf(field) === -1) {
-          console.warn(`Warning: ${field} is not a required or optional field: ${f}`)
+          console.warn(`Warning: ${f}: ${field} is not a required or optional field.`)
+          // FIXME: Some entries have extra fields (particularly `filename`)
         }
       }
     })
+
+    /**
+     * Rule: `name` must be a slug: lowercase alphanumeric plus hyphen only
+     */
     if (file['name'].match(/[^a-z\d-]/) !== null) {
-      console.warn(`Warning: Invalid 'name' field value '${file['name']}' in ${f}, only alphanumeric characters and hyphens are allowed`);
+      var properSlug = file['name'].toLowerCase().replace(/[^a-z\d-]+/g, '-')
+      console.warn(`Warning: ${f}: Invalid 'name' field value '${file['name']}', only alphanumeric characters and hyphens are allowed. Suggested value: '${properSlug}'`)
+      // FIXME: Many entries have improper `name` fields.
     }
-    // assert.ok(fields['name'].match(/[^\w\d-]/) !== null, `Invalid 'name' field value '${fields['name']}' in ${f}, only alphanumeric characters and hyphens are allowed`)
+
+    /**
+     * Rule: `vector` and `raster` images should exist and be relative to `hexb.in`
+     * FIXME: Maybe make this hosting-neutral
+     * FIXME: Vectors are missing, some are invalid.
+     */
+    // 'http://hexb.in/hexagons/' == 24 characters
+    // 'http://hexb.in/vector/' == 22 characters
+    // 'http://hexb.in/' == 15 characters
+    var rasterUrl = file.raster ? file.raster.slice(0, 24) : ''
+    var vectorUrl = file.vector ? file.vector.slice(0, 22) : ''
+    var rasterPath = file.raster ? file.raster.slice(15) : ''
+    var vectorPath = file.vector ? file.vector.slice(15) : ''
+    if (rasterUrl !== 'http://hexb.in/hexagons/') {
+      console.warn(`Warning: ${f}: 'raster' image '${file.raster}' must begin with 'http://hexb.in/hexagons/'`)
+    }
+    try {
+      fs.statSync(rasterPath)
+    } catch (e) {
+      console.warn(`Warning: ${f}: Couldn't find raster image at '${rasterPath}': ${e}`)
+    }
+    if (vectorUrl !== 'http://hexb.in/vector/') {
+      console.warn(`Warning: ${f}: 'vector' image '${file.vector}' must begin with 'http://hexb.in/vector/'`)
+    }
+    try {
+      fs.statSync(vectorPath)
+    } catch (e) {
+      console.warn(`Warning: ${f}: Couldn't find vector image at '${vectorPath}': ${e}`)
+    }
   })
 })


### PR DESCRIPTION
Connected to #107 

Currently **does not error** because there's a substantial amount of cleanup to be done (missing vectors, improper names, 'filename' all over the place, etc.) before rules can be enforced.

Follows #248 which makes `npm test` pass again